### PR TITLE
Add `exit': `q' => `os.Exit'

### DIFF
--- a/snippets/go-mode/exit
+++ b/snippets/go-mode/exit
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# key: q
+# name: exit
+# expand-env: ((yas-indent-line 'fixed))
+# uuid: E227B994
+# contributor: Grant Rettke <gcr@wisdomandwonder.com>
+# --
+os.Exit(${1:0})$0


### PR DESCRIPTION
This is a snippet for os.Exit. The first tab stop is the exit code, which defaults to 0. The last top is at the end of the entire statement.